### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
-def configurations = [
-    [ platform: "linux", jdk: "8" ],
-    [ platform: "linux", jdk: "11", javaLevel: "8" ]
-]
-buildPlugin(configurations: configurations)
+buildPlugin(configurations: [
+    [platform: 'linux', jdk: 8],
+    [platform: 'linux', jdk: 11],
+])


### PR DESCRIPTION
The `javaLevel` option is deprecated and no longer sets the Java version. The option is ignored. This PR removes the unused option.