### PR TITLE
Update parent POM, update dependencies, test with Java 21.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,9 @@
 /*
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
-*/ buildPlugin(
+*/
+buildPlugin(
+  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
   useContainerAgent: false, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 21],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,5 @@
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
+    [platform: 'linux', jdk: 17],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
 */ buildPlugin(
-  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  useContainerAgent: false, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 21],
     [platform: 'linux', jdk: 17],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,9 @@
-buildPlugin(configurations: [
-    [platform: 'linux', jdk: 8],
-    [platform: 'linux', jdk: 11],
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/ buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>toxiproxy</artifactId>
-            <version>1.16.2</version>
+            <version>1.19.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@ THE SOFTWARE.
 
     <url>https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin</url>
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
       <tag>HEAD</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -94,13 +94,13 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>1.16.2</version>
+            <version>1.19.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.16.3</version>
+            <version>1.19.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20211205</version>
+            <version>20231013</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.4-1203-jdbc4</version>
+            <version>42.6.0</version>
         </dependency>
         <dependency>
             <groupId>javax.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.44</version>
+        <version>4.75</version>
         <relativePath />
     </parent>
 
@@ -38,8 +38,7 @@ THE SOFTWARE.
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>2.308</jenkins.version>
-        <java.level>8</java.level>
+        <jenkins.version>2.387.3</jenkins.version>
         <useBeta>true</useBeta>
         <configuration-as-code.version>1.55.1</configuration-as-code.version>
     </properties>
@@ -58,27 +57,38 @@ THE SOFTWARE.
             <distribution>repo</distribution>
         </license>
     </licenses>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>2543.vfb_1a_5fb_9496d</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.32</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>1074.v60e6c29b_b_44b_</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -108,13 +118,11 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness</artifactId>
-            <version>1700.v6d3cd3101b_12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -140,11 +148,15 @@ THE SOFTWARE.
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>${configuration-as-code.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.json</groupId>
                     <artifactId>json</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- brought in by io.jenkins.plugins:commons-lang3-api -->
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
                 </exclusion>
             </exclusions>
             <scope>test</scope>
@@ -152,7 +164,6 @@ THE SOFTWARE.
         <dependency>
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
-            <version>${configuration-as-code.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.codehaus.jettison</groupId>
             <artifactId>jettison</artifactId>
-            <version>1.4.1</version>
+            <version>1.5.4</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/src/main/java/io/jenkins/plugins/postgresql/jettison/JettisonStaxWriter.java
+++ b/src/main/java/io/jenkins/plugins/postgresql/jettison/JettisonStaxWriter.java
@@ -86,6 +86,7 @@ public class JettisonStaxWriter extends StaxWriter {
      *             {@link JettisonStaxWriter#JettisonStaxWriter(QNameMap, XMLStreamWriter, boolean, boolean, NameCoder, MappedNamespaceConvention)}
      *             instead
      */
+    @Deprecated
     public JettisonStaxWriter(
             QNameMap qnameMap, XMLStreamWriter out, boolean writeEnclosingDocument,
             boolean namespaceRepairingMode, XmlFriendlyReplacer replacer,


### PR DESCRIPTION
Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is shallow. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Testing done
===

Confirmed tests pass with Java 21 on Linux.

Supersedes #197.
Supersedes #202. 
Supersedes #228. 
Supersedes #231. 
Supersedes #232.
Supersedes #233.
Supersedes #243.
Supersedes #245.
Supersedes #253. 
Supersedes #255.
Supersedes #256.
Supersedes #257.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue