### PR TITLE
JENKINS-72142 Move dependencies to API plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@ THE SOFTWARE.
             <scope>import</scope>
             <type>pom</type>
           </dependency>
+          <dependency>
+            <groupId>org.codehaus.jettison</groupId>
+            <artifactId>jettison</artifactId>
+            <version>1.5.4</version>
+          </dependency>
         </dependencies>
       </dependencyManagement>
     <dependencies>
@@ -84,14 +89,12 @@ THE SOFTWARE.
             <artifactId>postgresql-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.1.4</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jettison</groupId>
-            <artifactId>jettison</artifactId>
-            <version>1.5.4</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jersey2-api</artifactId>
         </dependency>
 
         <!-- Test dependencies -->
@@ -112,11 +115,6 @@ THE SOFTWARE.
             <artifactId>toxiproxy</artifactId>
             <version>1.19.2</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20231013</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins</groupId>


### PR DESCRIPTION
Replace dependencies by API plugin and should resolve future issue like JENKINS-72142

### Testing done

```
mvn clean install
mvn hpi:run -Dport=8081 -Dhost=0.0.0.0
```

[
![fingerprint_db](https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin/assets/825750/0ddcd9d0-1e32-4e1d-a6e1-846e96e7eb57)
![fingerprint](https://github.com/jenkinsci/postgresql-fingerprint-storage-plugin/assets/825750/e1a2b0e0-e293-4cd8-91ea-992dc879aec7)
](url)

Interactive testing show now issue

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```


